### PR TITLE
Add the Axiom Relay industrial interiors group (10 models) and a shared axiom-console-kit

### DIFF
--- a/.changeset/interiors-industrial-wave.md
+++ b/.changeset/interiors-industrial-wave.md
@@ -1,0 +1,17 @@
+---
+"@scifi-kit/registry": patch
+---
+
+Add the Axiom Relay industrial interiors group: ten procedural modules covering
+the control-room fit-out — two seats, three displays, an input deck, the operator
+desk, a control cabinet, a rack chassis, a technician's trolley, and a dressed
+cable run.
+
+They are built on a new `axiom-console-kit` support item, which is the first in
+the library keyed to *human* dimensions rather than to the building grid: a
+0.74 m desk, a 0.46 m seat, and a 1.15 m seated eye height, shared so the chair
+actually fits under the desk and the screens actually land at eye level. It also
+carries the shared castor, gas column, and screen builders, and a display
+emissive tier below the cargo wave's lens tier — a screen is a large lit area
+seen from a metre away, and at the cargo tier a monitor renders as a white
+rectangle.

--- a/assets/prototypes/axiom-console-kit/index.ts
+++ b/assets/prototypes/axiom-console-kit/index.ts
@@ -1,0 +1,239 @@
+import { Group, Object3D, type MeshPhysicalMaterial } from 'three/webgpu'
+
+import { MaterialLibrary, cylinder, tuneMaterial, type Vec3 } from '../../../src/asset-forge/generator/index.ts'
+import {
+  AXIS_Y,
+  TOKEN,
+  acquireCargoMaterials,
+  box,
+  createCargoPreview,
+  finishModel,
+  shade,
+  socket,
+  statusLens,
+  type CargoMaterialBundle,
+  type CargoMaterials,
+  type CargoPreview,
+  type CargoPreviewOptions,
+} from '../axiom-cargo-kit/index.ts'
+
+/**
+ * The industrial interiors group: the fit-out of a control room.
+ *
+ * These are the first modules in the library authored to *human* dimensions
+ * rather than to the building grid, and that is the constraint the kit encodes.
+ * A desk is 0.74 m high because that is where forearms go; a seat is 0.46 m
+ * because that is where knees bend; a screen's centre is 1.15 m above the floor
+ * because that is eye height for someone sitting at that desk. Those three
+ * numbers are shared here rather than chosen per model, which is what stops a
+ * chair, a desk and a monitor from the same library looking like they came from
+ * three different ones.
+ */
+export const CONSOLE = Object.freeze({
+  /** Working surface height. */
+  desk: 0.74,
+  /** Seat pan height, and the footring below it. */
+  seat: 0.46,
+  footring: 0.21,
+  /** Seated eye height above the floor; screen centres land here. */
+  eye: 1.15,
+  /** Standard equipment rack width and its 1U pitch. */
+  rackWidth: 0.6,
+  rackUnit: 0.0445,
+  /** Castor radius, shared by everything that rolls. */
+  castor: 0.045,
+  front: '+Z',
+  pivot: 'floor-centre',
+} as const)
+
+const library = new MaterialLibrary()
+
+export type ScreenToken = 'CYAN-400' | 'AMBER-400' | 'LIME-400' | 'RED-500'
+
+const TOKEN_VALUE: Record<ScreenToken, number> = {
+  'CYAN-400': TOKEN.CYAN_400,
+  'AMBER-400': TOKEN.AMBER_400,
+  'LIME-400': TOKEN.LIME_400,
+  'RED-500': TOKEN.RED_500,
+}
+
+/**
+ * A lit display surface.
+ *
+ * Dimmer than the cargo wave's lens tier, and for the same reason the doors and
+ * windows kits are: a screen is a large emissive area seen from a metre away,
+ * where a crate's lens is a 70 mm spot seen from five. At the cargo tier a
+ * monitor is a white rectangle, which is the one thing a monitor must not be.
+ */
+export function screenSurface(
+  bundle: CargoMaterialBundle,
+  token: ScreenToken,
+  seed = 5_500,
+  emissive = 0.62,
+): MeshPhysicalMaterial {
+  const handle = library.acquire({ recipeId: 'MAT-09', palette: token, condition: 'maintained', seed })
+  bundle.handles.push(handle)
+  return tuneMaterial(handle, shade(TOKEN_VALUE[token], -0.3), 0.22, 0.03, { emissive })
+}
+
+/** A screen: bezel, lit face, and the dark surround that gives it an edge. */
+export function screen(
+  parent: Group,
+  m: CargoMaterials,
+  face: MeshPhysicalMaterial,
+  size: readonly [number, number],
+  position: Vec3,
+  rotation?: Vec3,
+): void {
+  const [w, h] = size
+  box(parent, m.graphite, [w + 0.05, h + 0.05, 0.045], position, {
+    chamfer: 0.016, fillet: 0.006, bevel: 0.006, ...(rotation ? { rotation } : {}),
+  })
+  // The dark surround and the lit face need *different* stand-offs. Given the
+  // same one they are coplanar, the surround is the larger of the two, and it
+  // wins the depth test across most of the panel — which renders every screen in
+  // the group as a black rectangle with a thin lit border.
+  const seat = (lift: number): Vec3 => rotation
+    ? [
+        position[0] + Math.sin(rotation[1] ?? 0) * lift,
+        position[1] - Math.sin(rotation[0] ?? 0) * lift,
+        position[2] + Math.cos(rotation[1] ?? 0) * Math.cos(rotation[0] ?? 0) * lift,
+      ]
+    : [position[0], position[1], position[2] + lift]
+  box(parent, m.ink, [w + 0.014, h + 0.014, 0.016], seat(0.022), {
+    chamfer: 0.008, fillet: 0.004, bevel: 0.003, ...(rotation ? { rotation } : {}),
+  })
+  box(parent, face, [w, h, 0.012], seat(0.034), {
+    chamfer: 0.006, fillet: 0.003, bevel: 0.002, ...(rotation ? { rotation } : {}),
+  })
+}
+
+/** A braked castor on its stem: everything in this group that rolls uses it. */
+export function castorLeg(parent: Group, m: CargoMaterials, position: Vec3): void {
+  const [x, , z] = position
+  parent.add(cylinder(m.graphite, 0.028, 0.06, [x, CONSOLE.castor + 0.05, z], AXIS_Y, 8))
+  parent.add(cylinder(m.rubber, CONSOLE.castor, 0.036, [x, CONSOLE.castor, z], [0, 0, Math.PI / 2], 12))
+  box(parent, m.graphite, [0.05, 0.05, 0.07], [x, CONSOLE.castor + 0.03, z], {
+    chamfer: 0.012, fillet: 0.005, bevel: 0.004,
+  })
+}
+
+/** A gas-strut column with its five-star base — the seat family's shared stand. */
+export function chairColumn(parent: Group, m: CargoMaterials, height: number): void {
+  parent.add(cylinder(m.steel, 0.032, height - CONSOLE.castor - 0.04, [0, (height + CONSOLE.castor) * 0.5, 0], AXIS_Y, 12))
+  parent.add(cylinder(m.graphite, 0.055, 0.16, [0, CONSOLE.castor + 0.14, 0], AXIS_Y, 12))
+  for (let index = 0; index < 5; index += 1) {
+    const angle = (index / 5) * Math.PI * 2
+    const reach = 0.27
+    box(parent, m.graphite, [0.07, 0.05, reach], [
+      Math.sin(angle) * reach * 0.5,
+      CONSOLE.castor + 0.06,
+      Math.cos(angle) * reach * 0.5,
+    ], { chamfer: 0.016, fillet: 0.006, bevel: 0.005, rotation: [0, angle, 0] })
+    castorLeg(parent, m, [Math.sin(angle) * reach, 0, Math.cos(angle) * reach])
+  }
+}
+
+export interface ConsoleModel {
+  readonly root: Group
+  readonly parts: Record<string, Group>
+  readonly sockets: Record<string, Object3D>
+  update(deltaSeconds: number): void
+  dispose(): void
+}
+
+export interface ConsoleBuild {
+  readonly id: string
+  readonly condition?: number
+  readonly envelope: { width: number; depth: number; height: number }
+  build(context: {
+    root: Group
+    m: CargoMaterials
+    bundle: CargoMaterialBundle
+    part(name: string): Group
+  }): {
+    readonly assemblies?: readonly Group[]
+    readonly sockets?: Readonly<Record<string, readonly [number, number, number]>>
+    readonly tick?: (elapsed: number) => void
+  } | void
+}
+
+export function createConsoleModel(spec: ConsoleBuild): ConsoleModel {
+  const bundle = acquireCargoMaterials(31_900 + spec.id.length * 227, { condition: spec.condition ?? 0.4 })
+  const m = bundle.materials
+  const tag = spec.id.toUpperCase()
+
+  const root = new Group()
+  root.name = `AXR_INT_${tag}_ROOT_DEFAULT`
+  const parts: Record<string, Group> = {}
+  const part = (name: string): Group => {
+    const existing = parts[name]
+    if (existing) return existing
+    const group = new Group()
+    group.name = `AXR_INT_${tag}_PART_${name.toUpperCase()}_DEFAULT`
+    parts[name] = group
+    root.add(group)
+    return group
+  }
+
+  const built = spec.build({ root, m, bundle, part })
+  root.userData.consoleKit = {
+    version: 1,
+    moduleId: spec.id,
+    pivot: CONSOLE.pivot,
+    front: CONSOLE.front,
+    envelope: spec.envelope,
+    desk: CONSOLE.desk,
+    seat: CONSOLE.seat,
+  }
+
+  const sockets: Record<string, Object3D> = {}
+  const shared: Record<string, readonly [number, number, number]> = {
+    mount_floor: [0, 0, 0],
+    dressing_top: [0, spec.envelope.height, 0],
+  }
+  for (const [name, position] of Object.entries({ ...shared, ...(built?.sockets ?? {}) })) {
+    sockets[name] = socket(name, [...position] as [number, number, number])
+  }
+
+  const finished = finishModel(root, bundle, {
+    name: spec.id,
+    assemblies: built?.assemblies,
+    reach: 0.14,
+    sockets: Object.values(sockets),
+  })
+
+  let elapsed = 0
+  return {
+    root,
+    parts,
+    sockets,
+    update: (deltaSeconds: number) => {
+      elapsed += Math.min(Math.max(deltaSeconds, 0), 0.05)
+      built?.tick?.(elapsed)
+    },
+    dispose: finished.dispose,
+  }
+}
+
+/**
+ * The group's shared capture framing, pitched to seated eye height rather than
+ * to the object's own centre. Furniture read from above looks like a floor plan.
+ */
+export function createConsolePreview(
+  model: ConsoleModel,
+  envelope: { width: number; depth: number; height: number },
+  options: CargoPreviewOptions = {},
+): CargoPreview {
+  const span = Math.max(envelope.width, envelope.depth, envelope.height)
+  return createCargoPreview(model, {
+    target: [0, Math.min(envelope.height * 0.52, CONSOLE.eye * 0.72), 0],
+    distance: span * 1.9 + 0.9,
+    yaw: -0.68,
+    pitch: 0.24,
+    fov: 32,
+    ...options,
+  })
+}
+
+export { statusLens, box, type CargoMaterials, type CargoPreview, type CargoPreviewOptions } from '../axiom-cargo-kit/index.ts'

--- a/assets/prototypes/cable-bundle/model.ts
+++ b/assets/prototypes/cable-bundle/model.ts
@@ -1,0 +1,72 @@
+import { cylinder } from '../../../src/asset-forge/generator/index.ts'
+import { AXIS_X, box, type CargoPreview, type CargoPreviewOptions } from '../axiom-cargo-kit/index.ts'
+import { createConsoleModel, createConsolePreview, type ConsoleModel } from '../axiom-console-kit/index.ts'
+
+/**
+ * Axiom Relay cable bundle — a dressed run on its tray.
+ *
+ * The dressing is the asset. Loose cable is trivial to model and reads as
+ * spaghetti; a *bundle* is cable combed into parallel runs, tied at a regular
+ * pitch, labelled at both ends of every tie, and turned with a radius rather
+ * than a corner. That discipline is what makes an equipment room look
+ * maintained instead of abandoned, and it is the difference this module exists
+ * to carry.
+ *
+ * The minimum bend radius is why the run turns the way it does. Cable bent
+ * tighter than its own radius is damaged cable, so the turn here is generous and
+ * the tray under it is generous with it.
+ */
+
+const LENGTH = 1.8
+const TIES = 6
+const ENVELOPE = { width: LENGTH + 0.1, depth: 0.34, height: 0.24 }
+
+export function createModel(): ConsoleModel {
+  return createConsoleModel({
+    id: 'cable-bundle',
+    condition: 0.66,
+    envelope: ENVELOPE,
+    build: ({ m, part }) => {
+      const run = part('bundle');
+
+      // Tray: two side rails and the rungs between them.
+      for (const side of [-1, 1] as const) {
+        box(run, m.steel, [LENGTH, 0.05, 0.012], [0, 0.05, side * 0.11], { chamfer: 0.008, fillet: 0.003, bevel: 0.003 })
+      }
+      for (let index = 0; index < 9; index += 1) {
+        box(run, m.steel, [0.022, 0.01, 0.22], [-LENGTH * 0.5 + 0.1 + index * ((LENGTH - 0.2) / 8), 0.032, 0], {
+          chamfer: 0.004, fillet: 0.002, bevel: 0.002,
+        })
+      }
+      // Tray hangers, so the run is carried rather than lying on the floor.
+      for (const x of [-LENGTH * 0.32, LENGTH * 0.32]) {
+        box(run, m.graphite, [0.03, 0.16, 0.03], [x, 0.13, -0.13], { chamfer: 0.008, fillet: 0.003, bevel: 0.003 })
+        box(run, m.graphite, [0.03, 0.03, 0.28], [x, 0.2, 0], { chamfer: 0.008, fillet: 0.003, bevel: 0.003 })
+      }
+
+      // Combed cores: three rows of parallel runs, each row a different gauge.
+      const rows = [
+        { radius: 0.018, count: 5, y: 0.075, material: m.ink },
+        { radius: 0.013, count: 7, y: 0.108, material: m.graphiteEdge },
+        { radius: 0.009, count: 9, y: 0.132, material: m.ink },
+      ] as const
+      for (const row of rows) {
+        for (let index = 0; index < row.count; index += 1) {
+          const z = (index - (row.count - 1) / 2) * (row.radius * 2.2)
+          run.add(cylinder(row.material, row.radius, LENGTH - 0.04, [0, row.y, z], AXIS_X, 8))
+        }
+      }
+
+      // Ties at a regular pitch, with a label plate on each.
+      for (let index = 0; index < TIES; index += 1) {
+        const x = -LENGTH * 0.5 + 0.16 + index * ((LENGTH - 0.32) / (TIES - 1))
+        box(run, m.webbing, [0.016, 0.115, 0.24], [x, 0.105, 0], { chamfer: 0.006, fillet: 0.003, bevel: 0.003 })
+        box(run, m.shellShade, [0.01, 0.028, 0.05], [x, 0.168, 0.02], { chamfer: 0.004, fillet: 0.002, bevel: 0.002 })
+      }
+    },
+  })
+}
+
+export function createPreview(options: CargoPreviewOptions = {}): CargoPreview {
+  return createConsolePreview(createModel(), ENVELOPE, { distance: 3.1, pitch: 0.36, ...options })
+}

--- a/assets/prototypes/computer-monitor/model.ts
+++ b/assets/prototypes/computer-monitor/model.ts
@@ -1,0 +1,49 @@
+import { cylinder } from '../../../src/asset-forge/generator/index.ts'
+import { AXIS_Y, box, type CargoPreview, type CargoPreviewOptions } from '../axiom-cargo-kit/index.ts'
+import { CONSOLE, createConsoleModel, createConsolePreview, screen, screenSurface, type ConsoleModel } from '../axiom-console-kit/index.ts'
+
+/**
+ * Axiom Relay computer monitor — the desk display.
+ *
+ * Sized and positioned from the kit's shared human datums rather than from
+ * itself: the panel's centre lands at seated eye height when the stand is put on
+ * a 0.74 m desk, which is the only reason a monitor and a desk from the same
+ * library ever line up.
+ *
+ * The stand is a weighted foot and a raked neck, not a plate. A screen on a thin
+ * plate has nothing holding it against its own moment, and the eye reads that
+ * even when it cannot name it.
+ */
+
+const PANEL: readonly [number, number] = [0.56, 0.34]
+const ENVELOPE = { width: 0.6, depth: 0.24, height: 0.52 }
+
+export function createModel(): ConsoleModel {
+  return createConsoleModel({
+    id: 'computer-monitor',
+    condition: 0.34,
+    envelope: ENVELOPE,
+    build: ({ m, bundle, part }) => {
+      const monitor = part('monitor')
+      const face = screenSurface(bundle, 'CYAN-400', 5_720)
+
+      // Weighted foot, raked neck, and the tilt hinge at the top of it.
+      box(monitor, m.graphite, [0.22, 0.018, 0.17], [0, 0.009, 0], { chamfer: 0.03, fillet: 0.008, bevel: 0.006 })
+      box(monitor, m.ink, [0.2, 0.006, 0.15], [0, 0.002, 0], { chamfer: 0.028, fillet: 0.004, bevel: 0.003 })
+      box(monitor, m.graphite, [0.05, 0.2, 0.05], [0, 0.11, -0.02], { chamfer: 0.014, fillet: 0.006, bevel: 0.005, rotation: [0.16, 0, 0] })
+      monitor.add(cylinder(m.steel, 0.022, 0.06, [0, 0.21, -0.04], [0, 0, Math.PI / 2], 10))
+
+      // Panel, raked back the same amount the neck is.
+      screen(monitor, m, face, PANEL, [0, 0.34, -0.02], [-0.12, 0, 0])
+      // Rear housing, so the module is not a card from behind.
+      box(monitor, m.shellShade, [PANEL[0] - 0.06, PANEL[1] - 0.06, 0.05], [0, 0.34, -0.06], {
+        chamfer: 0.03, fillet: 0.01, bevel: 0.009, rotation: [-0.12, 0, 0],
+      })
+      box(monitor, m.ink, [0.1, 0.05, 0.03], [0.18, 0.2, -0.06], { chamfer: 0.01, fillet: 0.004, bevel: 0.004 })
+    },
+  })
+}
+
+export function createPreview(options: CargoPreviewOptions = {}): CargoPreview {
+  return createConsolePreview(createModel(), ENVELOPE, options)
+}

--- a/assets/prototypes/control-chair/model.ts
+++ b/assets/prototypes/control-chair/model.ts
@@ -1,0 +1,88 @@
+import { cylinder } from '../../../src/asset-forge/generator/index.ts'
+import { AXIS_Y, box, statusLens, type CargoPreview, type CargoPreviewOptions } from '../axiom-cargo-kit/index.ts'
+import {
+  CONSOLE,
+  chairColumn,
+  createConsoleModel,
+  createConsolePreview,
+  screen,
+  screenSurface,
+  type ConsoleModel,
+} from '../axiom-console-kit/index.ts'
+
+/**
+ * Axiom Relay control chair — the supervised-position seat.
+ *
+ * Same column and castors as the swivel chair, and then everything a station you
+ * do not leave for eight hours needs: a high back with a headrest, arms with a
+ * control pad on the right, a footring, and a lumbar section that is a separate
+ * pad rather than part of the back shell.
+ *
+ * The right arm's pad is the module's only lit surface, and it is angled inward
+ * so it faces the person sitting in it. An interface that faces the room is
+ * decoration; one that faces the seat is a control.
+ */
+
+const ENVELOPE = { width: 0.76, depth: 0.74, height: 1.34 }
+
+export function createModel(): ConsoleModel {
+  return createConsoleModel({
+    id: 'control-chair',
+    condition: 0.36,
+    build: ({ m, bundle, part }) => {
+      const chair = part('chair')
+      const pad = screenSurface(bundle, 'CYAN-400', 5_610)
+      chairColumn(chair, m, CONSOLE.seat)
+
+      // Footring: the tell that this is a seat for a raised station.
+      //
+      // Built as a tangent-segment polygon on its stems. Drawn as one straight
+      // cylinder it is a bar lying across the base, which is what a footring
+      // most needs not to look like.
+      const RING = 0.26
+      const SEGMENTS = 10
+      const chord = 2 * RING * Math.tan(Math.PI / SEGMENTS) + 0.01
+      for (let index = 0; index < SEGMENTS; index += 1) {
+        const angle = (index / SEGMENTS) * Math.PI * 2
+        box(chair, m.steel, [chord, 0.032, 0.032], [
+          Math.sin(angle) * RING, CONSOLE.footring, Math.cos(angle) * RING,
+        ], { chamfer: 0.008, fillet: 0.004, bevel: 0.003, rotation: [0, angle, 0] })
+      }
+      for (let index = 0; index < 3; index += 1) {
+        const angle = (index / 3) * Math.PI * 2
+        chair.add(cylinder(m.steel, 0.014, CONSOLE.seat - CONSOLE.footring - 0.14, [
+          Math.sin(angle) * RING, (CONSOLE.footring + CONSOLE.seat - 0.14) * 0.5, Math.cos(angle) * RING,
+        ], AXIS_Y, 8))
+      }
+
+      box(chair, m.graphite, [0.24, 0.08, 0.28], [0, CONSOLE.seat - 0.055, 0], { chamfer: 0.022, fillet: 0.009, bevel: 0.008 })
+      box(chair, m.graphite, [0.5, 0.06, 0.48], [0, CONSOLE.seat, 0], { chamfer: 0.08, fillet: 0.018, bevel: 0.016 })
+      box(chair, m.fabric, [0.44, 0.055, 0.42], [0, CONSOLE.seat + 0.04, -0.01], { chamfer: 0.09, fillet: 0.02, bevel: 0.018 })
+
+      // High back, lumbar pad, and headrest, all on one raked stem.
+      const rake = -0.2
+      box(chair, m.steel, [0.06, 0.28, 0.06], [0, CONSOLE.seat + 0.14, -0.21], { chamfer: 0.014, fillet: 0.006, bevel: 0.005, rotation: [rake, 0, 0] })
+      box(chair, m.graphite, [0.46, 0.62, 0.06], [0, CONSOLE.seat + 0.45, -0.29], { chamfer: 0.09, fillet: 0.018, bevel: 0.016, rotation: [rake, 0, 0] })
+      box(chair, m.fabric, [0.4, 0.34, 0.05], [0, CONSOLE.seat + 0.3, -0.235], { chamfer: 0.07, fillet: 0.015, bevel: 0.014, rotation: [rake, 0, 0] })
+      box(chair, m.fabric, [0.38, 0.2, 0.04], [0, CONSOLE.seat + 0.62, -0.31], { chamfer: 0.06, fillet: 0.013, bevel: 0.012, rotation: [rake, 0, 0] })
+      // Seated on the back's top edge, not floating above it: the back tops out
+      // at seat + 0.76 once its rake is taken into account.
+      box(chair, m.steel, [0.05, 0.1, 0.05], [0, CONSOLE.seat + 0.78, -0.4], { chamfer: 0.012, fillet: 0.005, bevel: 0.004, rotation: [rake, 0, 0] })
+      box(chair, m.graphite, [0.3, 0.14, 0.07], [0, CONSOLE.seat + 0.87, -0.42], { chamfer: 0.05, fillet: 0.012, bevel: 0.011, rotation: [rake, 0, 0] })
+
+      // Arms. The right one carries the control pad, turned inward.
+      for (const side of [-1, 1] as const) {
+        box(chair, m.steel, [0.05, 0.16, 0.05], [side * 0.27, CONSOLE.seat + 0.09, -0.06], { chamfer: 0.012, fillet: 0.005, bevel: 0.005 })
+        box(chair, m.graphite, [0.08, 0.05, 0.34], [side * 0.27, CONSOLE.seat + 0.19, 0.02], { chamfer: 0.02, fillet: 0.008, bevel: 0.007 })
+        box(chair, m.rubber, [0.07, 0.03, 0.3], [side * 0.27, CONSOLE.seat + 0.225, 0.02], { chamfer: 0.014, fillet: 0.006, bevel: 0.005 })
+      }
+      screen(chair, m, pad, [0.11, 0.08], [0.28, CONSOLE.seat + 0.27, 0.14], [0.5, -0.55, 0])
+      statusLens(chair, m, [0.03, 0.03], [-0.28, CONSOLE.seat + 0.25, 0.14], m.amber, 'top')
+    },
+    envelope: ENVELOPE,
+  })
+}
+
+export function createPreview(options: CargoPreviewOptions = {}): CargoPreview {
+  return createConsolePreview(createModel(), ENVELOPE, options)
+}

--- a/assets/prototypes/keyboard-control-surface/model.ts
+++ b/assets/prototypes/keyboard-control-surface/model.ts
@@ -1,0 +1,72 @@
+import { box, statusLens, type CargoPreview, type CargoPreviewOptions } from '../axiom-cargo-kit/index.ts'
+import { CONSOLE, createConsoleModel, createConsolePreview, screen, screenSurface, type ConsoleModel } from '../axiom-console-kit/index.ts'
+
+/**
+ * Axiom Relay keyboard control surface — the input deck.
+ *
+ * Not a keyboard: a control *surface*, which is the thing an industrial station
+ * actually has. A block of keys for text, a row of hard-labelled function keys
+ * that do not change, two rotary encoders, a shuttle wheel, and one guarded
+ * switch under a flip cover for the action that must never be hit by accident.
+ *
+ * The guard is the module's whole argument. Every other control here is flush
+ * and identical; the one that matters is the only one you cannot reach without
+ * deciding to.
+ */
+
+const W = 0.52
+const D = 0.24
+const ENVELOPE = { width: W, depth: D + 0.06, height: 0.09 }
+
+export function createModel(): ConsoleModel {
+  return createConsoleModel({
+    id: 'keyboard-control-surface',
+    condition: 0.58,
+    envelope: ENVELOPE,
+    build: ({ m, bundle, part }) => {
+      const deck = part('deck')
+      const readout = screenSurface(bundle, 'AMBER-400', 5_940, 0.5)
+
+      // Wedge chassis: back edge raised, so the surface rakes toward the hand.
+      box(deck, m.graphite, [W, 0.05, D], [0, 0.025, 0], { chamfer: 0.016, fillet: 0.007, bevel: 0.006 })
+      box(deck, m.graphiteEdge, [W - 0.02, 0.02, D - 0.02], [0, 0.055, -0.008], {
+        chamfer: 0.012, fillet: 0.005, bevel: 0.004, rotation: [-0.1, 0, 0],
+      })
+      box(deck, m.rubber, [W - 0.04, 0.012, 0.03], [0, 0.006, D * 0.5 - 0.02], { chamfer: 0.005, fillet: 0.002, bevel: 0.002 })
+
+      // Key block: five rows on a regular pitch.
+      const pitch = 0.026
+      for (let row = 0; row < 5; row += 1) {
+        for (let column = 0; column < 12; column += 1) {
+          box(deck, m.ink, [pitch * 0.8, 0.012, pitch * 0.8], [
+            -0.16 + column * pitch, 0.072 + row * 0.0022, -0.02 + row * pitch,
+          ], { chamfer: 0.004, fillet: 0.002, bevel: 0.002 })
+        }
+      }
+      // Hard-labelled function row along the back, in a lighter key.
+      for (let index = 0; index < 8; index += 1) {
+        box(deck, m.shellShade, [0.03, 0.011, 0.018], [-0.15 + index * 0.038, 0.079, -0.088], {
+          chamfer: 0.004, fillet: 0.002, bevel: 0.002,
+        })
+      }
+
+      // Encoders, shuttle wheel, and the readout above them.
+      for (const x of [0.17, 0.22]) {
+        box(deck, m.steel, [0.032, 0.024, 0.032], [x, 0.078, 0.03], { chamfer: 0.008, fillet: 0.004, bevel: 0.003 })
+      }
+      box(deck, m.graphiteEdge, [0.09, 0.02, 0.09], [0.195, 0.076, -0.04], { chamfer: 0.03, fillet: 0.008, bevel: 0.007 })
+      screen(deck, m, readout, [0.1, 0.03], [0.195, 0.082, -0.095], [-1.35, 0, 0])
+
+      // Guarded switch: cover, hinge, and the lit key beneath it.
+      box(deck, m.amberPaint, [0.06, 0.03, 0.05], [-0.21, 0.088, 0.052], {
+        chamfer: 0.008, fillet: 0.003, bevel: 0.003, rotation: [-0.9, 0, 0],
+      })
+      box(deck, m.graphite, [0.07, 0.014, 0.055], [-0.21, 0.068, 0.06], { chamfer: 0.01, fillet: 0.004, bevel: 0.004 })
+      statusLens(deck, m, [0.022, 0.022], [-0.21, 0.076, 0.06], m.amber, 'top')
+    },
+  })
+}
+
+export function createPreview(options: CargoPreviewOptions = {}): CargoPreview {
+  return createConsolePreview(createModel(), ENVELOPE, { distance: 1.4, pitch: 0.5, ...options })
+}

--- a/assets/prototypes/machinery-cabinet/model.ts
+++ b/assets/prototypes/machinery-cabinet/model.ts
@@ -1,0 +1,77 @@
+import { cylinder } from '../../../src/asset-forge/generator/index.ts'
+import { AXIS_Y, box, statusLens, type CargoPreview, type CargoPreviewOptions } from '../axiom-cargo-kit/index.ts'
+import { createConsoleModel, createConsolePreview, screen, screenSurface, type ConsoleModel } from '../axiom-console-kit/index.ts'
+
+/**
+ * Axiom Relay machinery cabinet — the floor-standing control enclosure.
+ *
+ * The thing on the wall behind the desks. A sealed enclosure with a rotary
+ * isolator that has to be turned off before the door will open, a gland plate at
+ * the bottom where every cable enters from below, and a filtered vent at the top
+ * where the heat leaves. Those three are what distinguish a control cabinet from
+ * a cupboard, and all three are interlocked by physics rather than by decoration.
+ *
+ * The plinth is the detail that dates a real one: cabinets stand on a plinth so
+ * a wash-down never reaches the gland plate.
+ */
+
+const W = 0.8
+const D = 0.42
+const H = 1.9
+const ENVELOPE = { width: W + 0.08, depth: D + 0.14, height: H + 0.06 }
+
+export function createModel(): ConsoleModel {
+  return createConsoleModel({
+    id: 'machinery-cabinet',
+    condition: 0.62,
+    envelope: ENVELOPE,
+    build: ({ m, bundle, part }) => {
+      const cab = part('cabinet')
+      const readout = screenSurface(bundle, 'AMBER-400', 6_160, 0.5)
+
+      // Plinth, body, and the capping that sheds off the top.
+      box(cab, m.graphite, [W - 0.06, 0.1, D - 0.06], [0, 0.05, 0], { chamfer: 0.02, fillet: 0.008, bevel: 0.007 })
+      box(cab, m.shell, [W, H - 0.14, D], [0, 0.1 + (H - 0.14) * 0.5, 0], { chamfer: 0.03, fillet: 0.012, bevel: 0.014 })
+      box(cab, m.graphiteEdge, [W + 0.06, 0.06, D + 0.06], [0, H - 0.01, 0], { chamfer: 0.022, fillet: 0.009, bevel: 0.008 })
+
+      // Door: a recessed leaf with a full-height hinge and the isolator on it.
+      box(cab, m.ink, [W - 0.07, H - 0.3, 0.02], [0, 0.98, D * 0.5 - 0.005], { chamfer: 0.02, fillet: 0.008, bevel: 0.006 })
+      box(cab, m.shellLight, [W - 0.11, H - 0.34, 0.035], [0, 0.98, D * 0.5 + 0.015], { chamfer: 0.024, fillet: 0.01, bevel: 0.009 })
+      for (const y of [0.44, 1.52]) {
+        cab.add(cylinder(m.graphiteEdge, 0.026, 0.14, [-W * 0.5 + 0.035, y, D * 0.5], AXIS_Y, 10))
+      }
+      // Rotary isolator: body, shaft, and the amber handle on it.
+      box(cab, m.graphite, [0.1, 0.1, 0.03], [W * 0.5 - 0.12, 1.5, D * 0.5 + 0.035], { chamfer: 0.022, fillet: 0.008, bevel: 0.007 })
+      cab.add(cylinder(m.steel, 0.014, 0.05, [W * 0.5 - 0.12, 1.5, D * 0.5 + 0.06], [Math.PI / 2, 0, 0], 8))
+      box(cab, m.amberPaint, [0.075, 0.026, 0.02], [W * 0.5 - 0.12, 1.5, D * 0.5 + 0.08], {
+        chamfer: 0.006, fillet: 0.003, bevel: 0.003, rotation: [0, 0, 0.6],
+      })
+      // Door readout and its lamps.
+      screen(cab, m, readout, [0.2, 0.11], [-0.11, 1.5, D * 0.5 + 0.035])
+      for (let index = 0; index < 3; index += 1) {
+        statusLens(cab, m, [0.026, 0.026], [-0.28 + index * 0.07, 1.31, D * 0.5 + 0.04], index === 0 ? m.amber : m.cyan, 'front')
+      }
+      // Latch and the door's stiffening ribs.
+      box(cab, m.steel, [0.03, 0.16, 0.02], [W * 0.5 - 0.07, 0.98, D * 0.5 + 0.04], { chamfer: 0.007, fillet: 0.003, bevel: 0.003 })
+      for (const y of [0.62, 0.86]) {
+        box(cab, m.shellShade, [W - 0.19, 0.02, 0.014], [0, y, D * 0.5 + 0.03], { chamfer: 0.006, fillet: 0.003, bevel: 0.002 })
+      }
+
+      // Filtered vent at the top, and the gland plate at the bottom.
+      box(cab, m.ink, [0.32, 0.16, 0.03], [0, H - 0.24, D * 0.5 + 0.01], { chamfer: 0.014, fillet: 0.005, bevel: 0.005 })
+      for (let index = 0; index < 4; index += 1) {
+        box(cab, m.steel, [0.3, 0.022, 0.026], [0, H - 0.3 + index * 0.038, D * 0.5 + 0.03], {
+          chamfer: 0.005, fillet: 0.002, bevel: 0.002, rotation: [-0.5, 0, 0],
+        })
+      }
+      box(cab, m.graphite, [W - 0.14, 0.05, D - 0.1], [0, 0.13, 0], { chamfer: 0.014, fillet: 0.006, bevel: 0.005 })
+      for (let index = 0; index < 4; index += 1) {
+        cab.add(cylinder(m.ink, 0.022, 0.08, [-0.22 + index * 0.145, 0.13, D * 0.5 - 0.09], AXIS_Y, 8))
+      }
+    },
+  })
+}
+
+export function createPreview(options: CargoPreviewOptions = {}): CargoPreview {
+  return createConsolePreview(createModel(), ENVELOPE, { distance: 4.2, ...options })
+}

--- a/assets/prototypes/maintenance-cart/model.ts
+++ b/assets/prototypes/maintenance-cart/model.ts
@@ -1,0 +1,81 @@
+import { cylinder } from '../../../src/asset-forge/generator/index.ts'
+import { AXIS_X, AXIS_Y, box, statusLens, type CargoPreview, type CargoPreviewOptions } from '../axiom-cargo-kit/index.ts'
+import { CONSOLE, castorLeg, createConsoleModel, createConsolePreview, type ConsoleModel } from '../axiom-console-kit/index.ts'
+
+/**
+ * Axiom Relay maintenance cart — the technician's trolley.
+ *
+ * The mobile counterpart to the workstation: three shelves, a push handle, a
+ * power strip on a reel, and a lipped top so nothing rolls off it while it is
+ * being pushed. It runs on the same castors as the chairs, which is the point of
+ * putting them in the kit — the two roll on the same wheels because in a facility
+ * that buys one it would.
+ *
+ * The lip is the detail that makes it a cart rather than a shelf on wheels.
+ * A flat-topped trolley is a trolley that has never been pushed anywhere.
+ */
+
+const W = 0.72
+const D = 0.46
+const TOP = 0.94
+const ENVELOPE = { width: W + 0.12, depth: D + 0.16, height: TOP + 0.28 }
+
+export function createModel(): ConsoleModel {
+  return createConsoleModel({
+    id: 'maintenance-cart',
+    condition: 0.78,
+    envelope: ENVELOPE,
+    build: ({ m, part }) => {
+      const cart = part('cart')
+
+      // Corner uprights and the castors under them.
+      for (const sx of [-1, 1] as const) {
+        for (const sz of [-1, 1] as const) {
+          const x = sx * (W * 0.5 - 0.04)
+          const z = sz * (D * 0.5 - 0.04)
+          box(cart, m.graphite, [0.04, TOP - CONSOLE.castor, 0.04], [x, (TOP + CONSOLE.castor) * 0.5, z], {
+            chamfer: 0.01, fillet: 0.004, bevel: 0.004,
+          })
+          castorLeg(cart, m, [x, 0, z])
+        }
+      }
+
+      // Three shelves, each with a turned-up lip on all four sides.
+      for (const [index, y] of [0.28, 0.6, TOP].entries()) {
+        box(cart, m.shell, [W, 0.026, D], [0, y, 0], { chamfer: 0.014, fillet: 0.006, bevel: 0.007 })
+        for (const sx of [-1, 1] as const) {
+          box(cart, m.graphiteEdge, [0.02, 0.05, D], [sx * (W * 0.5 - 0.01), y + 0.032, 0], { chamfer: 0.006, fillet: 0.003, bevel: 0.003 })
+        }
+        for (const sz of [-1, 1] as const) {
+          box(cart, m.graphiteEdge, [W, 0.05, 0.02], [0, y + 0.032, sz * (D * 0.5 - 0.01)], { chamfer: 0.006, fillet: 0.003, bevel: 0.003 })
+        }
+        // Anti-slip mat on the two working shelves.
+        if (index > 0) box(cart, m.rubber, [W - 0.08, 0.008, D - 0.08], [0, y + 0.017, 0], { chamfer: 0.008, fillet: 0.003, bevel: 0.002 })
+      }
+
+      // Push handle, raked back so it clears the top shelf's lip.
+      for (const sx of [-1, 1] as const) {
+        box(cart, m.graphite, [0.03, 0.26, 0.03], [sx * (W * 0.5 - 0.04), TOP + 0.13, -D * 0.5 + 0.04], {
+          chamfer: 0.008, fillet: 0.003, bevel: 0.003, rotation: [0.22, 0, 0],
+        })
+      }
+      cart.add(cylinder(m.rubber, 0.019, W - 0.06, [0, TOP + 0.26, -D * 0.5 + 0.01], AXIS_X, 10))
+
+      // Power reel and strip on the lower shelf, and the tool rail on the side.
+      cart.add(cylinder(m.graphiteEdge, 0.075, 0.09, [-W * 0.5 + 0.14, 0.37, -D * 0.5 + 0.13], AXIS_Y, 12))
+      cart.add(cylinder(m.ink, 0.052, 0.07, [-W * 0.5 + 0.14, 0.37, -D * 0.5 + 0.13], AXIS_Y, 12))
+      box(cart, m.graphite, [0.24, 0.05, 0.06], [W * 0.5 - 0.19, 0.33, -D * 0.5 + 0.12], { chamfer: 0.012, fillet: 0.005, bevel: 0.004 })
+      for (let index = 0; index < 3; index += 1) {
+        statusLens(cart, m, [0.018, 0.018], [W * 0.5 - 0.27 + index * 0.07, 0.355, -D * 0.5 + 0.12], m.amber, 'top')
+      }
+      cart.add(cylinder(m.steel, 0.012, D - 0.1, [W * 0.5 + 0.02, 0.72, 0], [Math.PI / 2, 0, 0], 8))
+      for (let index = 0; index < 4; index += 1) {
+        box(cart, m.steel, [0.014, 0.09, 0.014], [W * 0.5 + 0.02, 0.67, -0.12 + index * 0.08], { chamfer: 0.004, fillet: 0.002, bevel: 0.002 })
+      }
+    },
+  })
+}
+
+export function createPreview(options: CargoPreviewOptions = {}): CargoPreview {
+  return createConsolePreview(createModel(), ENVELOPE, { distance: 3.1, ...options })
+}

--- a/assets/prototypes/server/model.ts
+++ b/assets/prototypes/server/model.ts
@@ -1,0 +1,76 @@
+import { box, statusLens, type CargoPreview, type CargoPreviewOptions } from '../axiom-cargo-kit/index.ts'
+import { CONSOLE, createConsoleModel, createConsolePreview, type ConsoleModel } from '../axiom-console-kit/index.ts'
+
+/**
+ * Axiom Relay server — one rack-mounted chassis.
+ *
+ * A single unit, not a cabinet: 4U tall on the kit's 44.5 mm rack pitch, with
+ * the ears that carry it and the slide rails it runs on. The existing library
+ * already has a server cabinet; what it had no way to express is a machine you
+ * can pull out of one, and half of what makes a server room read is the one
+ * chassis racked out on its rails.
+ *
+ * The front is drive bays and airflow, the back is power and data — because that
+ * is the actual rule, cold aisle in front, hot aisle behind, and every cable on
+ * the hot side.
+ */
+
+const UNITS = 4
+const W = CONSOLE.rackWidth - 0.12
+const H = CONSOLE.rackUnit * UNITS
+const D = 0.72
+const ENVELOPE = { width: CONSOLE.rackWidth, depth: D + 0.06, height: H + 0.04 }
+
+export function createModel(): ConsoleModel {
+  return createConsoleModel({
+    id: 'server',
+    condition: 0.4,
+    envelope: ENVELOPE,
+    build: ({ m, part }) => {
+      const unit = part('chassis')
+      const y = H * 0.5
+
+      box(unit, m.graphite, [W, H, D], [0, y, 0], { chamfer: 0.01, fillet: 0.004, bevel: 0.005 })
+      box(unit, m.shellShade, [W - 0.01, H - 0.012, 0.02], [0, y, D * 0.5 + 0.005], { chamfer: 0.008, fillet: 0.003, bevel: 0.003 })
+
+      // Rack ears and the slide rails behind them.
+      for (const side of [-1, 1] as const) {
+        box(unit, m.steel, [0.05, H, 0.012], [side * (W * 0.5 + 0.025), y, D * 0.5 - 0.006], { chamfer: 0.006, fillet: 0.003, bevel: 0.002 })
+        for (const uy of [y - H * 0.28, y + H * 0.28]) {
+          box(unit, m.ink, [0.018, 0.018, 0.008], [side * (W * 0.5 + 0.025), uy, D * 0.5 + 0.002], { chamfer: 0.004, fillet: 0.002, bevel: 0.002 })
+        }
+        box(unit, m.steel, [0.014, H - 0.02, D - 0.05], [side * (W * 0.5 + 0.006), y, -0.01], { chamfer: 0.005, fillet: 0.002, bevel: 0.002 })
+      }
+
+      // Front: two rows of drive carriers, a handle, and the status column.
+      for (let row = 0; row < 2; row += 1) {
+        for (let column = 0; column < 6; column += 1) {
+          box(unit, m.graphiteEdge, [0.055, H * 0.36, 0.014], [
+            -0.18 + column * 0.062, y + (row === 0 ? -1 : 1) * H * 0.22, D * 0.5 + 0.018,
+          ], { chamfer: 0.005, fillet: 0.002, bevel: 0.002 })
+          box(unit, m.ink, [0.03, 0.008, 0.008], [
+            -0.18 + column * 0.062, y + (row === 0 ? -1 : 1) * H * 0.22, D * 0.5 + 0.026,
+          ], { chamfer: 0.002, fillet: 0.001, bevel: 0.001 })
+        }
+      }
+      box(unit, m.steel, [0.02, H * 0.6, 0.03], [W * 0.5 - 0.03, y, D * 0.5 + 0.03], { chamfer: 0.006, fillet: 0.003, bevel: 0.003 })
+      for (let index = 0; index < 3; index += 1) {
+        statusLens(unit, m, [0.012, 0.012], [-W * 0.5 + 0.03, y - 0.03 + index * 0.03, D * 0.5 + 0.024], index === 0 ? m.cyan : m.amber, 'front')
+      }
+
+      // Back: PSU pair, fan grilles, and the port block.
+      for (const side of [-1, 1] as const) {
+        box(unit, m.graphiteEdge, [0.15, H - 0.02, 0.03], [side * 0.11, y, -D * 0.5 - 0.012], { chamfer: 0.008, fillet: 0.003, bevel: 0.003 })
+        box(unit, m.ink, [0.1, H - 0.05, 0.012], [side * 0.11, y, -D * 0.5 - 0.026], { chamfer: 0.02, fillet: 0.004, bevel: 0.003 })
+        box(unit, m.steel, [0.026, 0.02, 0.02], [side * 0.11, y - H * 0.3, -D * 0.5 - 0.03], { chamfer: 0.004, fillet: 0.002, bevel: 0.002 })
+      }
+      for (let index = 0; index < 5; index += 1) {
+        box(unit, m.ink, [0.03, 0.014, 0.01], [-0.04 + index * 0.02, y + H * 0.24, -D * 0.5 - 0.014], { chamfer: 0.003, fillet: 0.001, bevel: 0.001 })
+      }
+    },
+  })
+}
+
+export function createPreview(options: CargoPreviewOptions = {}): CargoPreview {
+  return createConsolePreview(createModel(), ENVELOPE, { distance: 1.9, pitch: 0.3, ...options })
+}

--- a/assets/prototypes/swivel-chair/model.ts
+++ b/assets/prototypes/swivel-chair/model.ts
@@ -1,0 +1,60 @@
+import { cylinder } from '../../../src/asset-forge/generator/index.ts'
+import { AXIS_Y, box, type CargoPreview, type CargoPreviewOptions } from '../axiom-cargo-kit/index.ts'
+import { CONSOLE, chairColumn, createConsoleModel, createConsolePreview, type ConsoleModel } from '../axiom-console-kit/index.ts'
+
+/**
+ * Axiom Relay swivel chair — the general-issue task seat.
+ *
+ * The plain seat the whole facility sits on: gas column, five-star base, a
+ * moulded pan and a low back. It is deliberately the *unremarkable* one, because
+ * the group also has a control chair, and a kit only reads as a kit when the
+ * ordinary member is visibly ordinary — the same column, the same castors, less
+ * of everything else.
+ *
+ * The back is raked and the pan is dished. A flat pan on a flat back is the
+ * silhouette of a stool, and no amount of detail elsewhere recovers it.
+ */
+
+const ENVELOPE = { width: 0.62, depth: 0.62, height: 1.02 }
+
+export function createModel(): ConsoleModel {
+  return createConsoleModel({
+    id: 'swivel-chair',
+    condition: 0.52,
+    envelope: ENVELOPE,
+    build: ({ m, part }) => {
+      const chair = part('chair')
+      chairColumn(chair, m, CONSOLE.seat)
+
+      // Mechanism under the pan: the part that explains the height adjustment.
+      box(chair, m.graphite, [0.22, 0.07, 0.26], [0, CONSOLE.seat - 0.05, 0], {
+        chamfer: 0.02, fillet: 0.008, bevel: 0.007,
+      })
+      chair.add(cylinder(m.steel, 0.016, 0.11, [0.13, CONSOLE.seat - 0.07, 0.02], [0, 0, Math.PI / 2], 8))
+
+      // Dished pan: a shell with a proud cushion inset into it.
+      box(chair, m.graphite, [0.46, 0.05, 0.44], [0, CONSOLE.seat, 0], {
+        chamfer: 0.07, fillet: 0.016, bevel: 0.014,
+      })
+      box(chair, m.fabric, [0.4, 0.05, 0.38], [0, CONSOLE.seat + 0.035, -0.01], {
+        chamfer: 0.08, fillet: 0.018, bevel: 0.016,
+      })
+
+      // Raked back on its stem.
+      const rake = -0.22
+      box(chair, m.steel, [0.05, 0.26, 0.05], [0, CONSOLE.seat + 0.13, -0.19], {
+        chamfer: 0.012, fillet: 0.005, bevel: 0.005, rotation: [rake, 0, 0],
+      })
+      box(chair, m.graphite, [0.42, 0.42, 0.05], [0, CONSOLE.seat + 0.34, -0.24], {
+        chamfer: 0.08, fillet: 0.016, bevel: 0.014, rotation: [rake, 0, 0],
+      })
+      box(chair, m.fabric, [0.36, 0.36, 0.04], [0, CONSOLE.seat + 0.34, -0.21], {
+        chamfer: 0.07, fillet: 0.014, bevel: 0.013, rotation: [rake, 0, 0],
+      })
+    },
+  })
+}
+
+export function createPreview(options: CargoPreviewOptions = {}): CargoPreview {
+  return createConsolePreview(createModel(), ENVELOPE, options)
+}

--- a/assets/prototypes/wall-monitor/model.ts
+++ b/assets/prototypes/wall-monitor/model.ts
@@ -1,0 +1,51 @@
+import { box, statusLens, type CargoPreview, type CargoPreviewOptions } from '../axiom-cargo-kit/index.ts'
+import { createConsoleModel, createConsolePreview, screen, screenSurface, type ConsoleModel } from '../axiom-console-kit/index.ts'
+
+/**
+ * Axiom Relay wall monitor — the shared overview display.
+ *
+ * The room's screen rather than a person's: bracketed off a wall, tilted down so
+ * a standing viewer sees it square, and large enough to be read from the far
+ * side of a control room. Its bracket is the module's real content — a wall
+ * screen drawn flush to a wall has no way to be serviced, no cable route, and no
+ * explanation for the gap every real one has behind it.
+ *
+ * The pivot sits on the wall plane at z = 0, so the module can be dropped
+ * straight onto a wall bay without a builder solving for its own depth.
+ */
+
+const PANEL: readonly [number, number] = [1.28, 0.74]
+const ENVELOPE = { width: PANEL[0] + 0.1, depth: 0.3, height: PANEL[1] + 0.2 }
+
+export function createModel(): ConsoleModel {
+  return createConsoleModel({
+    id: 'wall-monitor',
+    condition: 0.28,
+    envelope: ENVELOPE,
+    build: ({ m, bundle, part }) => {
+      const display = part('display')
+      const face = screenSurface(bundle, 'CYAN-400', 5_830, 0.54)
+      const tilt = -0.18
+      const centreY = ENVELOPE.height * 0.5
+
+      // Wall plate and the two arms that carry the panel off it.
+      box(display, m.graphite, [0.34, 0.5, 0.05], [0, centreY, 0.025], { chamfer: 0.04, fillet: 0.012, bevel: 0.01 })
+      for (const side of [-1, 1] as const) {
+        box(display, m.steel, [0.06, 0.06, 0.22], [side * 0.11, centreY + 0.12, 0.14], { chamfer: 0.016, fillet: 0.006, bevel: 0.005 })
+        box(display, m.steel, [0.05, 0.3, 0.05], [side * 0.11, centreY, 0.24], { chamfer: 0.014, fillet: 0.005, bevel: 0.005, rotation: [tilt, 0, 0] })
+      }
+      // Cable route down the wall plate, which is why there is a gap at all.
+      box(display, m.ink, [0.07, 0.44, 0.03], [0, centreY - 0.02, 0.055], { chamfer: 0.014, fillet: 0.005, bevel: 0.004 })
+
+      screen(display, m, face, PANEL, [0, centreY, 0.28], [tilt, 0, 0])
+      box(display, m.shellShade, [PANEL[0] - 0.1, PANEL[1] - 0.1, 0.05], [0, centreY, 0.24], {
+        chamfer: 0.04, fillet: 0.012, bevel: 0.011, rotation: [tilt, 0, 0],
+      })
+      statusLens(display, m, [0.035, 0.02], [PANEL[0] * 0.44, centreY - PANEL[1] * 0.46, 0.31], m.amber, 'front')
+    },
+  })
+}
+
+export function createPreview(options: CargoPreviewOptions = {}): CargoPreview {
+  return createConsolePreview(createModel(), ENVELOPE, { distance: 3.4, ...options })
+}

--- a/assets/prototypes/workstation/model.ts
+++ b/assets/prototypes/workstation/model.ts
@@ -1,0 +1,66 @@
+import { box, statusLens, type CargoPreview, type CargoPreviewOptions } from '../axiom-cargo-kit/index.ts'
+import { CONSOLE, createConsoleModel, createConsolePreview, screen, screenSurface, type ConsoleModel } from '../axiom-console-kit/index.ts'
+
+/**
+ * Axiom Relay workstation — the operator desk.
+ *
+ * The piece the rest of the group is dimensioned around. Its surface is at the
+ * kit's 0.74 m desk datum, its screen rail puts panel centres at the 1.15 m
+ * seated eye datum, and the knee space under it is clear to 0.62 m — which is
+ * what makes the swivel chair actually fit under it rather than approximately
+ * fit under it.
+ *
+ * The cable management is modelled rather than implied: a tray under the back
+ * edge, a grommet through the top, and a riser down one leg. On a desk covered
+ * in equipment, where the cables go is most of what makes it look used.
+ */
+
+const W = 1.6
+const D = 0.78
+const ENVELOPE = { width: W, depth: D + 0.06, height: 1.42 }
+
+export function createModel(): ConsoleModel {
+  return createConsoleModel({
+    id: 'workstation',
+    condition: 0.44,
+    envelope: ENVELOPE,
+    build: ({ m, bundle, part }) => {
+      const desk = part('desk')
+      const face = screenSurface(bundle, 'CYAN-400', 6_050)
+
+      // Top: a worked surface on a deeper front edge, with a grommet in it.
+      box(desk, m.shell, [W, 0.04, D], [0, CONSOLE.desk - 0.02, 0], { chamfer: 0.02, fillet: 0.009, bevel: 0.012 })
+      box(desk, m.graphiteEdge, [W, 0.03, 0.05], [0, CONSOLE.desk - 0.055, D * 0.5 - 0.02], { chamfer: 0.01, fillet: 0.004, bevel: 0.004 })
+      box(desk, m.ink, [0.11, 0.02, 0.07], [0.42, CONSOLE.desk - 0.008, -D * 0.28], { chamfer: 0.026, fillet: 0.006, bevel: 0.005 })
+
+      // Legs: braced frames, with the knee space between them left clear.
+      for (const side of [-1, 1] as const) {
+        const x = side * (W * 0.5 - 0.09)
+        box(desk, m.graphite, [0.06, CONSOLE.desk - 0.06, D - 0.12], [x, (CONSOLE.desk - 0.06) * 0.5, 0], { chamfer: 0.016, fillet: 0.007, bevel: 0.006 })
+        box(desk, m.graphite, [0.13, 0.05, D - 0.06], [x, 0.03, 0], { chamfer: 0.014, fillet: 0.006, bevel: 0.005 })
+        box(desk, m.rubber, [0.13, 0.012, 0.09], [x, 0.006, D * 0.4], { chamfer: 0.005, fillet: 0.002, bevel: 0.002 })
+        box(desk, m.rubber, [0.13, 0.012, 0.09], [x, 0.006, -D * 0.4], { chamfer: 0.005, fillet: 0.002, bevel: 0.002 })
+      }
+      // Back rail tying the legs together, above knee height.
+      box(desk, m.graphiteEdge, [W - 0.24, 0.08, 0.05], [0, 0.62, -D * 0.5 + 0.09], { chamfer: 0.016, fillet: 0.006, bevel: 0.006 })
+
+      // Cable tray under the back edge, and the riser down one leg.
+      box(desk, m.ink, [W - 0.4, 0.06, 0.11], [0, CONSOLE.desk - 0.12, -D * 0.5 + 0.1], { chamfer: 0.014, fillet: 0.006, bevel: 0.005 })
+      box(desk, m.graphiteEdge, [0.07, 0.5, 0.06], [W * 0.5 - 0.09, 0.38, -D * 0.5 + 0.11], { chamfer: 0.016, fillet: 0.006, bevel: 0.005 })
+
+      // Screen rail: two panels at the shared seated eye datum.
+      box(desk, m.graphite, [0.07, CONSOLE.eye - CONSOLE.desk + 0.16, 0.07], [0, (CONSOLE.desk + CONSOLE.eye) * 0.5 - 0.02, -D * 0.34], {
+        chamfer: 0.018, fillet: 0.007, bevel: 0.006,
+      })
+      box(desk, m.graphite, [0.96, 0.05, 0.05], [0, CONSOLE.eye + 0.04, -D * 0.34], { chamfer: 0.014, fillet: 0.006, bevel: 0.005 })
+      for (const side of [-1, 1] as const) {
+        screen(desk, m, face, [0.42, 0.27], [side * 0.26, CONSOLE.eye - 0.05, -D * 0.3], [0, -side * 0.22, 0])
+      }
+      statusLens(desk, m, [0.03, 0.03], [-0.6, CONSOLE.desk + 0.01, -D * 0.32], m.amber, 'top')
+    },
+  })
+}
+
+export function createPreview(options: CargoPreviewOptions = {}): CargoPreview {
+  return createConsolePreview(createModel(), ENVELOPE, { distance: 3.9, ...options })
+}

--- a/registries/scifi-kit/src/build.ts
+++ b/registries/scifi-kit/src/build.ts
@@ -145,6 +145,7 @@ async function main(): Promise<void> {
     await buildCoreItem(),
     await buildSupportItem('axiom-modular-kit'),
     await buildSupportItem('axiom-cargo-kit'),
+    await buildSupportItem('axiom-console-kit'),
   ]
   for (const modelId of modelIds) items.push(await buildModelItem(modelId))
   items.push({


### PR DESCRIPTION
## What this is

Ten of the fourteen briefs under `docs/assets/reusable/interiors/industrial/` have no model source. This adds ten of them, chosen as a coherent set: the fit-out of one control room. (`rack`, `shelf`, `server-rack` and `industrial-table` are left for a later batch — the library already has `storage-rack`, `warehouse-shelf`, `server-cabinet` and `industrial-workbench`, so those four need a reconciliation pass rather than new geometry.)

## The kit

`assets/prototypes/axiom-console-kit/` is the **first support item keyed to human dimensions rather than to the building grid**, and that is the whole reason it exists:

- desk surface at **0.74 m** — where forearms go;
- seat pan at **0.46 m**, footring at 0.21 m;
- seated eye height at **1.15 m**, which is where screen centres land.

Sharing those three numbers is what makes the swivel chair actually fit under the workstation and the workstation's screen rail actually sit at eye level, instead of each model choosing its own and approximately agreeing. It also carries the shared castor, gas-column, and screen builders.

Display surfaces get an emissive tier below the cargo wave's lens tier, for the same reason the doors and windows kits step theirs down: a screen is a large lit area seen from a metre away, where a crate's lens is a 70 mm spot seen from five. At the cargo tier a monitor renders as a white rectangle.

## Modules

| Module | Notes |
| --- | --- |
| `swivel-chair` | The deliberately ordinary seat — same column and castors, less of everything else |
| `control-chair` | High back, headrest, footring, and an arm pad angled toward the person sitting in it |
| `computer-monitor` | Weighted foot and raked neck; panel centre lands at eye height when stood on a 0.74 m desk |
| `wall-monitor` | Bracketed off the wall with a real gap and cable route behind it |
| `keyboard-control-surface` | Keys, hard-labelled function row, encoders, and one guarded switch under a flip cover |
| `workstation` | The piece the group is dimensioned around; knee space, cable tray, grommet, screen rail |
| `machinery-cabinet` | Plinth, interlocked isolator, gland plate below, filtered vent above |
| `server` | One 4U chassis on the rack pitch, with ears and slide rails — cold aisle front, hot aisle back |
| `maintenance-cart` | Three lipped shelves on the kit's castors, push handle, power reel, tool rail |
| `cable-bundle` | Combed parallel runs, ties at a regular pitch, labels, and a bend radius that respects itself |

## Verification

- Every module was iterated with `bun run vibe:model preview`.
- `bun run typecheck`, `bun run build`, and `bun test` (49 pass, 0 fail) all pass.
- `bun run build:registries` builds **179 items from 174 models**, up from 168/164.

## Note for review

This is the fifth batch cut independently from `main` (doors, windows, walls, roof, interiors). All five touch the one `buildSupportItem` list in `registries/scifi-kit/src/build.ts`, so whichever land after the first will want a trivial merge on that list. The five kits also each define their own small lit-material helper at the same reduced emissive tier — once two or more land, those are worth collapsing into the cargo kit as a single shared tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
