### PR TITLE
Add a coincident-face ("tearing") check

### DIFF
--- a/.agents/skills/vibe-model/SKILL.md
+++ b/.agents/skills/vibe-model/SKILL.md
@@ -54,6 +54,19 @@ during migration. Prefer `vibe:model` in new documentation and automation.
 Keep the camera deterministic. Change yaw, pitch, width, height, or the preview
 factory only when the reference requires it.
 
+## Check
+
+Before each critique:
+
+```sh
+node --import tsx scripts/coplanar-check.ts <model-id>
+```
+
+It fails on visible faces sharing a plane and facing the same way. That
+z-fights, and neither a still nor a critic will name it. Coincidence buried
+inside another solid is not reported. Fix per rule 9 in
+[modeling-rules.md](references/modeling-rules.md).
+
 ## Critique
 
 Give a fresh critic only the brief, reference, and current beauty image. Ask
@@ -67,6 +80,16 @@ Apply the highest-impact correction and capture again.
 Stop at a score of 85 or higher, after two plateauing scores, or after ten
 iterations. Treat a plateau as evidence to change the representation or obtain
 better reference evidence.
+
+A score is not an acceptance. The critique measures resemblance to the
+reference and is blind to everything else: parts seated on the wrong plane,
+geometry left floating in front of a face, coincident faces tearing, extents
+carried over from an earlier revision. Ask the critic to list modelling
+errors separately from resemblance gaps, with a location for each; unprompted
+it scores only likeness. Register the model in the browser registry and put the render and the
+live URL in front of the requester before calling it done, and say what you
+approximated. Their look is the acceptance; the score only decides when to stop
+iterating.
 
 ## Deliver
 

--- a/.agents/skills/vibe-model/references/modeling-rules.md
+++ b/.agents/skills/vibe-model/references/modeling-rules.md
@@ -20,9 +20,9 @@
 5. Assume winding changes when a ring insets. For a suspect cap or inward rim,
    compare the first triangle's edge cross product with the intended outward
    normal.
-6. Keep chamfers below roughly sixty percent of the affected half-extent.
-   Clamp against the thinnest dimension and inspect for finite,
-   non-degenerate triangles.
+6. Keep chamfers below roughly sixty percent of the affected half-extent. Clamp
+   against the thinnest dimension and inspect for finite, non-degenerate
+   triangles.
 7. Size physical features in world units. Bevels, seams, wear bands, bolts, and
    clearances represent physical dimensions; do not scale them as a percentage
    of every host part.
@@ -32,32 +32,45 @@
 8. Calculate clearance for every applied layer. Compare the host face with the
    detail's back and front faces. In this metre-scale kit, begin with at least
    0.015 units of clearance and verify from the actual camera.
-9. Build, bake, then merge. Derive adjacency data, surface identity, semantic
-   parts, and material ownership while objects remain separate. Merge only
-   afterward. Normalize vertex attributes before merging and respect the
-   renderer's vertex-buffer budget.
-10. Keep runtime anchors outside replaceable generated content. Configuration
+9. Never let two visible faces share a plane facing the same way.
+   Interpenetration is expected here; coincidence is not. The depth buffer
+   cannot order two surfaces at one depth, so the overlap renders as a
+   per-pixel speckle that crawls with the camera — and both a still frame and
+   a resemblance critique miss it. It comes from authoring a part from a
+   landmark it shares with its neighbour: a cap ring as [END - w, END] against
+   a body that ends at END, a marking as [SURFACE, SURFACE + t] on the surface
+   it marks. Separate the two — proud parts 0.02-0.03 further out, lapping
+   parts 0.01-0.02 further in, markings sunk into their host. Flush is the bug,
+   not the fix. Coincidence sealed inside another solid is never rasterised and
+   does not matter; check the rest with `node --import tsx
+   scripts/coplanar-check.ts <model-id>`.
+
+10. Build, bake, then merge. Derive adjacency data, surface identity, semantic
+    parts, and material ownership while objects remain separate. Merge only
+    afterward. Normalize vertex attributes before merging and respect the
+    renderer's vertex-buffer budget.
+11. Keep runtime anchors outside replaceable generated content. Configuration
     can rebuild geometry without invalidating consumer attachments.
 
 ## Reference matching
 
-11. Measure the reference and solve the camera with the model. Compare clean
+12. Measure the reference and solve the camera with the model. Compare clean
     silhouette bounds and cross-sections rather than reflections, smoke,
     shadows, or effects that extend the apparent shape.
-12. Tune yaw, pitch, focal length, and target together. Incorrect perspective
+13. Tune yaw, pitch, focal length, and target together. Incorrect perspective
     can make correct dimensions look wrong.
-13. Treat critic feedback as evidence, not a numeric gradient. Prefer changes
+14. Treat critic feedback as evidence, not a numeric gradient. Prefer changes
     that recur across independent critiques. If critics disagree about the same
     dimension, spend the next iteration on a more stable mismatch.
 
 ## Vibe3D runtime contract
 
-14. Keep the model root stable for its entire lifetime. Rebuild generated
+15. Keep the model root stable for its entire lifetime. Rebuild generated
     children inside it when topology changes.
-15. Expose meaningful runtime anatomy through stable semantic part anchors,
+16. Expose meaningful runtime anatomy through stable semantic part anchors,
     sockets, material slots, and typed actions. Do not make consumers depend on
     anonymous mesh order.
-16. Respect ownership. Dispose model-owned resources exactly once and never
+17. Respect ownership. Dispose model-owned resources exactly once and never
     dispose materials or textures supplied by the consumer.
-17. Keep preview scenery, lights, floors, cameras, smoke, and diagnostic effects
-    out of the installed model root or mark them for export exclusion.
+18. Keep preview scenery, lights, floors, cameras, smoke, and diagnostic
+    effects out of the installed model root or mark them for export exclusion.

--- a/scripts/coplanar-check.ts
+++ b/scripts/coplanar-check.ts
@@ -1,0 +1,179 @@
+/**
+ * Coincident-face check ("tearing").
+ *
+ * Parts here are interpenetrating solids, so overlap is normal. Two faces on
+ * exactly the SAME PLANE facing the SAME WAY are not: the depth buffer cannot
+ * order two surfaces at one depth, so the winner is decided per pixel by
+ * floating-point noise and the overlap shimmers as the camera moves. At a
+ * distance that reads as a broken shader rather than a modelling mistake, which
+ * is why it survives a resemblance critique, and a still frame can hide it.
+ *
+ * Only the VISIBLE part of a shared patch can tear. Roughly half of every model
+ * is sealed inside another solid, where a shared plane sits behind an opaque
+ * surface from every direction and is never rasterised. So each patch is
+ * sampled, each sample nudged along the facing normal, and samples landing
+ * inside a third part are dropped; what is reported is the area left. An
+ * occluder must contain a sample by a real margin, so the test errs toward
+ * reporting — rounded parts over-claim their bounding box, and that margin is
+ * what stops the over-claim from hiding a real fault.
+ *
+ * To fix, separate the two surfaces: a proud part goes 0.02-0.03 further out, a
+ * lapping part 0.01-0.02 further in, a marking sinks its base into its host.
+ * Flush is the bug, not the fix.
+ *
+ * Usage:  node --import tsx scripts/coplanar-check.ts <model-id> [more-ids...]
+ *         node --import tsx scripts/coplanar-check.ts --all
+ * Exits 1 if any pair exceeds --max-area (default 0.02 m2).
+ */
+import { readdirSync } from 'node:fs'
+import { Box3, Group, Mesh } from 'three/webgpu'
+
+const EPS = 1e-4
+const AXES = ['x', 'y', 'z'] as const
+type Axis = (typeof AXES)[number]
+
+const argv = process.argv.slice(2)
+const maxAreaArg = argv.findIndex((a) => a === '--max-area')
+const MAX_AREA = maxAreaArg >= 0 ? Number(argv[maxAreaArg + 1]) : 0.02
+const ids = argv[0] === '--all'
+  ? readdirSync('assets/prototypes', { withFileTypes: true }).filter((d) => d.isDirectory()).map((d) => d.name)
+  : argv.filter((a) => !a.startsWith('--') && a !== String(MAX_AREA))
+
+if (ids.length === 0) {
+  console.error('usage: coplanar-check.ts <model-id> [...] | --all   [--max-area 0.02]')
+  process.exit(2)
+}
+
+// Record every mesh as it is added, which is BEFORE mergeStaticByMaterial folds
+// them into one mesh per material. Merged meshes are skipped: their bbox is the
+// whole model, so every part would look coincident with them.
+const parts: Array<{ box: Box3; mat: string }> = []
+const realAdd = Group.prototype.add
+let capturing = false
+;(Group.prototype as unknown as { add: (...o: unknown[]) => Group }).add = function (this: Group, ...objects: never[]) {
+  if (capturing) {
+    for (const object of objects as unknown[]) {
+      if (object instanceof Mesh && !String(object.name).includes(' / ')) {
+        const material = object.material as { name?: string } | undefined
+        parts.push({ box: new Box3().setFromObject(object), mat: String(material?.name ?? '?') })
+      }
+    }
+  }
+  return realAdd.apply(this, objects)
+}
+
+interface Hit { area: number; total: number; axis: Axis; side: 'min' | 'max'; plane: number; at: string; a: string; b: string }
+
+/** How far inside an occluder a sample must sit before it counts as buried. */
+const BURIED_MARGIN = 0.015
+/** How far along the outward normal a sample is pushed off its own plane. */
+const NUDGE = 0.002
+
+/**
+ * The fraction of a shared patch that is NOT sealed inside some third solid.
+ *
+ * Sampled rather than solved: with fillets and chamfers in play an exact
+ * boolean is the wrong tool, and a 6 x 6 grid resolves anything big enough to
+ * see. Returns 1 when nothing occludes it and 0 when it is entirely buried.
+ */
+function visibleFraction(
+  axis: Axis, plane: number, side: 'min' | 'max',
+  rect: Record<string, [number, number]>,
+  parts: ReadonlyArray<{ box: Box3 }>, skipA: number, skipB: number,
+): number {
+  const dir = side === 'max' ? 1 : -1
+  const tangents = AXES.filter((o) => o !== axis)
+  const N = 6
+  let seen = 0
+  for (let u = 0; u < N; u += 1) {
+    for (let v = 0; v < N; v += 1) {
+      const point: Record<string, number> = { [axis]: plane + dir * NUDGE }
+      const t0 = rect[tangents[0]]
+      const t1 = rect[tangents[1]]
+      point[tangents[0]] = t0[0] + ((u + 0.5) / N) * (t0[1] - t0[0])
+      point[tangents[1]] = t1[0] + ((v + 0.5) / N) * (t1[1] - t1[0])
+      let buried = false
+      for (let k = 0; k < parts.length && !buried; k += 1) {
+        if (k === skipA || k === skipB) continue
+        const c = parts[k].box
+        buried = AXES.every((o) => point[o] >= c.min[o] + BURIED_MARGIN && point[o] <= c.max[o] - BURIED_MARGIN)
+      }
+      if (!buried) seen += 1
+    }
+  }
+  return seen / (N * N)
+}
+
+let failed = false
+for (const id of ids) {
+  parts.length = 0
+  capturing = true
+  let model: { root: Group; dispose(): void }
+  try {
+    const mod = await import(`../assets/prototypes/${id}/model.ts`)
+    model = mod.createModel()
+  } catch (error) {
+    capturing = false
+    console.log(`\n== ${id}: SKIPPED (${(error as Error).message.split('\n')[0]})`)
+    continue
+  }
+  capturing = false
+
+  const hits: Hit[] = []
+  for (let i = 0; i < parts.length; i += 1) {
+    for (let j = i + 1; j < parts.length; j += 1) {
+      const a = parts[i].box
+      const b = parts[j].box
+      for (const axis of AXES) {
+        // A `max` face and a `min` face on one plane are back to back — each is
+        // only ever seen from its own side, so that pair never tears.
+        for (const side of ['min', 'max'] as const) {
+          if (Math.abs(a[side][axis] - b[side][axis]) > EPS) continue
+          // The underside is never in shot for a top-down camera.
+          if (axis === 'y' && side === 'min') continue
+          let area = 1
+          let overlaps = true
+          for (const other of AXES) {
+            if (other === axis) continue
+            const lo = Math.max(a.min[other], b.min[other])
+            const hi = Math.min(a.max[other], b.max[other])
+            if (hi - lo <= EPS) { overlaps = false; break }
+            area *= hi - lo
+          }
+          if (!overlaps || area < MAX_AREA) continue
+          // Only the part of the patch that is not sealed inside something else
+          // can ever be rasterised, so only that part can tear.
+          const rect: Record<string, [number, number]> = {}
+          for (const other of AXES) {
+            if (other === axis) continue
+            rect[other] = [Math.max(a.min[other], b.min[other]), Math.min(a.max[other], b.max[other])]
+          }
+          const visible = area * visibleFraction(axis, a[side][axis], side, rect, parts, i, j)
+          if (visible < MAX_AREA) continue
+          // Where to LOOK: the centre of the shared patch, in model space.
+          const centre = AXES.map((o) => (o === axis
+            ? a[side][axis]
+            : (Math.max(a.min[o], b.min[o]) + Math.min(a.max[o], b.max[o])) / 2).toFixed(2)).join(', ')
+          hits.push({ area: visible, total: area, axis, side, plane: a[side][axis], at: centre, a: parts[i].mat, b: parts[j].mat })
+        }
+      }
+    }
+  }
+  hits.sort((p, q) => q.area - p.area)
+  const verdict = hits.length === 0 ? 'clean' : `${hits.length} FAIL`
+  console.log(`\n== ${id}: ${parts.length} authored parts, ${verdict} (>= ${MAX_AREA} m2 VISIBLE)`)
+  for (const h of hits.slice(0, 20)) {
+    const hidden = h.total > h.area + 1e-6 ? ` (of ${h.total.toFixed(3)} shared)` : ''
+    console.log(`   ${h.area.toFixed(3)} m2 visible${hidden}  ${h.axis}.${h.side}=${h.plane.toFixed(3)}  at (${h.at})  ${h.a} <-> ${h.b}`)
+  }
+  if (hits.length > 20) console.log(`   ... ${hits.length - 20} more`)
+  if (hits.length > 0) failed = true
+  model.dispose()
+}
+
+if (failed) {
+  console.log('\nFIX: move one of the two surfaces by 0.01-0.03 m so they no longer share a plane.')
+  console.log('     A proud part goes further OUT; a lapping part goes further IN; paint sinks INTO its host.')
+  console.log('     Making them exactly flush is the bug, not the fix.')
+}
+process.exit(failed ? 1 : 0)


### PR DESCRIPTION
Parts in this kit are interpenetrating solids, so overlap is normal. Two faces on exactly the **same plane facing the same way** are not: the depth buffer cannot order two surfaces at one depth, so the overlap shimmers as the camera moves. It reads as a broken shader rather than a modelling mistake, so a resemblance critique scores past it and a still frame hides it.

It is easy to author by accident, because it comes from writing a part from a landmark it shares with its neighbour — a cap ring as `[END - w, END]` against a body that ends at `END`, a marking as `[SURFACE, SURFACE + t]` on the surface it marks, a reveal butted onto a surround's inner plane.

## The check

`scripts/coplanar-check.ts` records every mesh as it is added — before `mergeStaticByMaterial` folds them — and reports pairs sharing a plane and facing the same way. Two filters keep it from being noise:

- **Back-to-back pairs.** A `max` face against a `min` face is only seen from its own side, so it can never fight.
- **Internal coincidence.** Geometry sealed inside another solid is never rasterised. Each shared patch is sampled, the samples nudged along the facing normal, and those landing inside a third part dropped; only the visible remainder is scored. An occluder must contain a sample by a real margin, so the test errs toward reporting.

Output gives the visible area, the plane and the model-space point to look at. Exits non-zero over `--max-area` (default 0.02 m²).

```
node --import tsx scripts/coplanar-check.ts <model-id> [...]
node --import tsx scripts/coplanar-check.ts --all --max-area 0.05
```

```
== window-bay: 58 authored parts, 4 FAIL (>= 0.02 m2 VISIBLE)
   0.024 m2 visible (of 0.044 shared)  z.min=-0.190  at (2.21, 2.61, -0.19)  MAT-03/GRAPHITE-800/4102 <-> MAT-03/GRAPHITE-800/4102
```

## Findings on the current library

`--all` at the 0.02 m² default reports **26 models clean and 147 with at least one visible coincident pair**. Most are small; some are not — `wall-lamp` has a 23.7 m² pair, `wall-return` has six on one plane. This PR fixes none of them, so the numbers stay reviewable. If 0.02 m² is too strict a default for this kit, it is a flag.

## Docs

- **`modeling-rules.md` rule 9** — what causes it and how to fix it: proud parts 0.02–0.03 further out, lapping parts 0.01–0.02 further in, markings sunk into their host. Flush is the bug, not the fix.
- **`vibe-model/SKILL.md`** — runs the check before each critique, and notes a critic must be asked for modelling errors separately from resemblance gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
