### PR TITLE
Seed @medieval-kit in the init template

### DIFF
--- a/models.json
+++ b/models.json
@@ -14,6 +14,10 @@
     "@scifi-kit": {
       "source": "file:registries/scifi-kit/dist/registry.json",
       "version": "workspace"
+    },
+    "@medieval-kit": {
+      "source": "npm:@medieval-kit/registry",
+      "version": "latest"
     }
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -49,6 +49,7 @@ async function initialize(cwd: string): Promise<void> {
     aliases: { vibe3d: '@/lib/vibe3d', models: '@/models' },
     registries: {
       '@scifi-kit': { source: 'npm:@scifi-kit/registry', version: 'latest' },
+      '@medieval-kit': { source: 'npm:@medieval-kit/registry', version: 'latest' },
     },
   }
   const createdConfig = await writeNewFile(configPath, `${JSON.stringify(config, null, 2)}\n`)


### PR DESCRIPTION
`vibe3d init` seeds `@scifi-kit` only, so `bunx vibe3d add @medieval-kit` stops with
`Registry @medieval-kit is not configured in models.json` until you hand-edit the file.
This adds the entry so a fresh init can install it directly.

@medieval-kit is 37 procedural lowpoly medieval props, MIT, published as
`@medieval-kit/registry` on npm. Source distribution like @scifi-kit: you get the
TypeScript that generates the model. Viewer for all of them: https://medieval.crt.fyi/